### PR TITLE
Enable VAE slicing and tiling to reduce memory usage during training

### DIFF
--- a/train.py
+++ b/train.py
@@ -285,6 +285,11 @@ def training_loop(
     vae = AutoencoderKL.from_pretrained("stabilityai/sd-vae-ft-ema").to(device)
     vae.eval()
     vae.requires_grad_(False)
+    # torch.compile's CUDA-graph pools hold ~90 GiB during eval; slice/tile
+    # the decoder so a batch_gpu-sized VAE decode still fits.
+    vae.enable_slicing()
+    if image_size >= 1024:
+        vae.enable_tiling()
 
     # Resume
     cur_nimg = 0


### PR DESCRIPTION
## Summary
This change optimizes memory usage during the training loop by enabling VAE slicing and tiling, which prevents CUDA graph pools from consuming excessive memory during evaluation.

## Key Changes
- Enable VAE slicing to reduce memory footprint during decoding operations
- Enable VAE tiling for high-resolution images (>= 1024px) to further optimize memory usage
- Added explanatory comment noting that torch.compile's CUDA-graph pools can hold ~90 GiB during eval without these optimizations

## Implementation Details
The VAE slicing and tiling are enabled after the model is loaded and set to evaluation mode. Tiling is conditionally enabled only for larger image sizes (1024px and above) where memory pressure is more likely to be an issue. This allows batch-GPU-sized VAE decoding to fit within available memory constraints.

https://claude.ai/code/session_01AgNZCJX3Dgb2RXbYd9RU1p