### PR TITLE
Add optional combra metrics integration for training evaluation

### DIFF
--- a/diffit/metrics.py
+++ b/diffit/metrics.py
@@ -14,6 +14,17 @@ from diffit import NUM_CLASSES
 from diffit.constants import PIXEL_NORM_HALF, UINT8_MAX, VAE_SCALE_FACTOR
 from diffit.dpm_solver import dpm_solver_sample
 
+# Optional combra integration: score generated samples with combra's
+# generative-quality metrics during training. The import is guarded so training
+# runs unchanged when combra is not installed.
+try:
+    from combra.metrics import compute_all_metrics as _combra_compute_all_metrics
+
+    HAS_COMBRA = True
+except ImportError:
+    _combra_compute_all_metrics = None
+    HAS_COMBRA = False
+
 
 @torch.inference_mode()
 def compute_activations(images_uint8_nchw, extractor, batch_size, device, desc="Computing Inception features"):
@@ -225,10 +236,18 @@ def evaluate_metrics(
     rank=0, world_size=1,
     log_fn=None,
     class_list=None, null_class_idx=None,
+    ref_images=None, combra_cache=None,
 ):
     """Generate samples across all ranks, compute metrics on rank 0.
 
     class_list / null_class_idx: forwarded to generate_eval_samples. See there.
+
+    ref_images: NCHW uint8 reference images. When provided and combra is
+        installed, the generated batch is also scored with
+        ``combra.metrics.compute_all_metrics`` and the results are merged into
+        the returned dict under ``combra_*`` keys. combra_cache: a caller-owned
+        dict reused across calls to memoise the reference-side combra work.
+
     Returns dict of metrics on rank 0, None on other ranks.
     """
     if log_fn is None:
@@ -267,6 +286,15 @@ def evaluate_metrics(
     if rank == 0:
         metrics["Precision"] = prec
         metrics["Recall"] = rec
+        if ref_images is not None and HAS_COMBRA:
+            try:
+                combra_metrics = _combra_compute_all_metrics(
+                    ref_images, fake_images, device=device, reference_cache=combra_cache,
+                )
+                for k, v in combra_metrics.items():
+                    metrics[f"combra_{k}"] = float(v)
+            except Exception as e:  # combra failure must not abort the eval tick
+                log_fn(f"  combra metrics failed: {e}")
         for k, v in metrics.items():
             log_fn(f"  {k}: {v:.4f}")
         return metrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,11 @@ dev = [
     "pytest>=7.0.0",
     "ruff>=0.4.0",
 ]
+# Optional: enables combra.metrics.compute_all_metrics during training-time eval.
+# Training runs unchanged without it (the import is guarded).
+combra = [
+    "combra",
+]
 
 # Console entry-points. After `pip install -e .` these are available on PATH.
 # (For distributed sampling use `torchrun ... -m scripts.sample` instead, since

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -43,6 +43,7 @@ from diffit.dpm_solver import dpm_solver_sample
 from diffit.image_datasets import load_data
 from diffit.inception import InceptionFeatureExtractor
 from diffit.metrics import (
+    HAS_COMBRA,
     compute_activations,
     evaluate_metrics,
 )
@@ -335,6 +336,8 @@ def training_loop(
     # --- Load Inception model + pre-compute reference features (rank 0 only) ---
     inception_extractor = None
     ref_acts = None
+    combra_ref_images = None  # kept for combra metrics when combra is installed
+    combra_ref_cache = {} if HAS_COMBRA else None
     if is_main and num_fid_samples > 0:
         logger.log("Loading InceptionV3 for metric evaluation...")
         from torchvision.models import Inception_V3_Weights, inception_v3
@@ -356,7 +359,10 @@ def training_loop(
             n_collected += batch_np.shape[0]
         ref_images = np.concatenate(ref_images, axis=0)[:num_fid_samples]
         ref_acts = compute_activations(ref_images, inception_extractor, batch_size=64, device=device)
-        del ref_images
+        if HAS_COMBRA:
+            combra_ref_images = ref_images  # reused as the combra reference batch
+        else:
+            del ref_images
         logger.log("Reference features computed.")
 
     # Build class-sorted grid: each row cycles through classes
@@ -621,6 +627,7 @@ def training_loop(
                         log_fn=logger.log,
                         class_list=list(range(num_dataset_classes)),
                         null_class_idx=num_dataset_classes,
+                        ref_images=combra_ref_images, combra_cache=combra_ref_cache,
                     )
                     # Only rank 0 logs and saves metrics
                     if is_main and stats_metrics is not None:


### PR DESCRIPTION
## Summary
This PR adds optional integration with the combra library to compute generative quality metrics during training evaluation. The integration is entirely optional—training runs unchanged when combra is not installed, thanks to guarded imports.

## Key Changes
- **diffit/metrics.py**: Added guarded import of combra's `compute_all_metrics` function with `HAS_COMBRA` flag to detect availability. Extended `evaluate_metrics()` to accept `ref_images` and `combra_cache` parameters and compute combra metrics when both are provided and combra is installed. Combra failures are caught and logged without aborting the evaluation tick.

- **scripts/train.py**: Updated to import and check `HAS_COMBRA` flag. Modified training loop to preserve reference images when combra is available for reuse in metric computation. Pass reference images and cache dict to `evaluate_metrics()` calls.

- **pyproject.toml**: Added optional `combra` dependency group for users who want to enable this feature.

## Implementation Details
- The combra integration uses a caller-owned cache dict (`combra_ref_cache`) to memoize reference-side computation across multiple evaluation calls, improving efficiency.
- Combra metrics are prefixed with `combra_` in the returned metrics dict to distinguish them from standard metrics.
- Exception handling ensures that combra metric failures don't interrupt the training evaluation loop, maintaining robustness.
- The feature is completely transparent when combra is not installed—no performance impact or behavioral changes.

https://claude.ai/code/session_011eMsRFR4ScNg9NbhiTPvj5