### PR TITLE
Add configurable sampler for eval/snapshot generation

### DIFF
--- a/diffit/image_datasets.py
+++ b/diffit/image_datasets.py
@@ -29,6 +29,7 @@ def load_data(
     num_workers=4,
     distributed=False,
     cache_in_ram=False,
+    drop_last=True,
 ):
     """
     Create a generator over (images, kwargs) pairs.
@@ -87,7 +88,7 @@ def load_data(
         sampler=sampler,
         num_workers=num_workers,
         pin_memory=True,
-        drop_last=True,
+        drop_last=drop_last,
         persistent_workers=num_workers > 0,
     )
     # Advance the DistributedSampler epoch each pass so every rank gets
@@ -111,6 +112,19 @@ def _list_image_files_recursively(data_dir):
         elif os.path.isdir(full_path):
             results.extend(_list_image_files_recursively(full_path))
     return results
+
+
+def count_data(data_dir):
+    """Return the number of images in a dataset directory or .zip archive."""
+    if not data_dir:
+        raise ValueError("unspecified data directory")
+    if data_dir.endswith(".zip"):
+        with zipfile.ZipFile(data_dir, "r") as zf:
+            return sum(
+                1 for name in zf.namelist()
+                if name.split(".")[-1].lower() in ("png", "jpg", "jpeg", "gif")
+            )
+    return len(_list_image_files_recursively(data_dir))
 
 
 class ImageDataset(Dataset):

--- a/diffit/metrics.py
+++ b/diffit/metrics.py
@@ -43,11 +43,33 @@ def compute_activations(images_uint8_nchw, extractor, batch_size, device, desc="
     }
 
 
+def sample_latents(model_fn, diffusion, shape, device, *, sampler, num_steps, model_kwargs, noise, progress=False):
+    """Dispatch latent sampling to the chosen reverse-diffusion sampler.
+
+    sampler: "dpm++" runs DPM-Solver++(2M) on the full schedule (``diffusion`` must
+        carry the full 1000-step ``alphas_cumprod``; ``num_steps`` sets the solver
+        steps). "ddim" / "ddpm" use the native deterministic-DDIM / ancestral-DDPM
+        loops, in which case ``diffusion`` must be a SpacedDiffusion whose
+        ``num_timesteps`` already encodes the step count (``num_steps`` is ignored).
+        DDIM uses the default ``eta=0`` (deterministic).
+    """
+    if sampler == "dpm++":
+        return dpm_solver_sample(
+            model_fn, diffusion, shape, device,
+            num_steps=num_steps, model_kwargs=model_kwargs, noise=noise, progress=progress,
+        )
+    sample_fn = diffusion.ddim_sample_loop if sampler == "ddim" else diffusion.p_sample_loop
+    return sample_fn(
+        model_fn, shape, noise=noise, clip_denoised=False,
+        model_kwargs=model_kwargs, device=device, progress=progress,
+    )
+
+
 @torch.inference_mode()
 def generate_eval_samples(
     ema_model, vae, diffusion, num_samples, batch_gpu, latent_size, device,
     *,
-    cfg_scale, num_sampling_steps=25, scale_pow=4.0,
+    cfg_scale, num_sampling_steps=25, scale_pow=4.0, sampler="dpm++",
     rank=0, world_size=1,
     class_list=None, null_class_idx=None,
 ):
@@ -70,7 +92,7 @@ def generate_eval_samples(
     all_images = []
     generated = 0
     show_progress = (rank == 0)
-    pbar = tqdm(total=local_target, desc=f"Generating eval samples (dpm++{num_sampling_steps})", unit="img") if show_progress else None
+    pbar = tqdm(total=local_target, desc=f"Generating eval samples ({sampler}×{num_sampling_steps})", unit="img") if show_progress else None
     while generated < local_target:
         bs = min(batch_gpu, local_target - generated)
         z = torch.randn(bs, 4, latent_size, latent_size, device=device)
@@ -85,11 +107,12 @@ def generate_eval_samples(
             "scale_pow": scale_pow,
         }
         with torch.amp.autocast("cuda", dtype=torch.float16):
-            sample = dpm_solver_sample(
+            sample = sample_latents(
                 ema_model.forward_with_cfg,
                 diffusion,
                 z_cfg.shape,
                 device,
+                sampler=sampler,
                 num_steps=num_sampling_steps,
                 model_kwargs=model_kwargs,
                 noise=z_cfg,
@@ -233,6 +256,7 @@ def evaluate_metrics(
     num_fid_samples, batch_gpu, latent_size, device,
     *,
     cfg_scale,
+    sampler="dpm++", num_sampling_steps=25,
     rank=0, world_size=1,
     log_fn=None,
     class_list=None, null_class_idx=None,
@@ -257,11 +281,13 @@ def evaluate_metrics(
         n_cls = len(class_list) if class_list is not None else NUM_CLASSES
         log_fn(
             f"Evaluating metrics ({num_fid_samples} samples across "
-            f"{world_size} GPU(s), cfg_scale={cfg_scale}, classes={n_cls})..."
+            f"{world_size} GPU(s), sampler={sampler}×{num_sampling_steps}, "
+            f"cfg_scale={cfg_scale}, classes={n_cls})..."
         )
     fake_images = generate_eval_samples(
         ema_model, vae, diffusion, num_fid_samples, batch_gpu, latent_size, device,
         cfg_scale=cfg_scale,
+        num_sampling_steps=num_sampling_steps, sampler=sampler,
         rank=rank, world_size=world_size,
         class_list=class_list, null_class_idx=null_class_idx,
     )

--- a/scripts/gen_images.py
+++ b/scripts/gen_images.py
@@ -59,6 +59,7 @@ import diffit.diffit as diffit_module
 from diffit import create_diffusion, diffusion_defaults
 from diffit.constants import PIXEL_NORM_HALF, UINT8_MAX, VAE_SCALE_FACTOR
 from diffit.dist_util import load_state_dict
+from diffit.metrics import sample_latents
 
 
 def parse_range(s: Union[str, List, None]) -> List[int]:
@@ -328,7 +329,7 @@ def _merge_shards_to_one_h5(
 
 def _run_sampling(model, vae, diffusion, dev, latent_size, num_classes,
                   bs, class_labels, gen, *, cfg_scale, scale_pow,
-                  diffusion_steps, use_ddim):
+                  diffusion_steps, sampler, num_sampling_steps):
     """Single forward pass: bs latents → bs decoded uint8 NHWC images."""
     z = torch.randn(bs, 4, latent_size, latent_size, device=dev, generator=gen)
     classes_null = torch.full((bs,), num_classes, device=dev, dtype=torch.long)
@@ -341,12 +342,15 @@ def _run_sampling(model, vae, diffusion, dev, latent_size, num_classes,
         "scale_pow": scale_pow,
     }
 
-    sample_fn = diffusion.ddim_sample_loop if use_ddim else diffusion.p_sample_loop
-    sample = sample_fn(
+    sample = sample_latents(
         model.forward_with_cfg,
-        z_cfg.shape, z_cfg,
-        clip_denoised=False, progress=False,
-        model_kwargs=model_kwargs, device=dev,
+        diffusion,
+        z_cfg.shape,
+        dev,
+        sampler=sampler,
+        num_steps=num_sampling_steps,
+        model_kwargs=model_kwargs,
+        noise=z_cfg,
     )
     sample, _ = sample.chunk(2, dim=0)
 
@@ -377,7 +381,7 @@ def _run_sampling(model, vae, diffusion, dev, latent_size, num_classes,
 @click.option("--class-idx", type=int, default=None, help="Seed mode: fixed class label (random if not specified)")
 @click.option("--cfg-scale", type=float, default=4.4, show_default=True, help="Classifier-free guidance scale")
 @click.option("--num-sampling-steps", type=int, default=250, show_default=True, help="Number of diffusion sampling steps")
-@click.option("--use-ddim/--no-use-ddim", default=False, show_default=True, help="Use DDIM sampling")
+@click.option("--sampler", type=click.Choice(["dpm++", "ddim", "ddpm"]), default="ddim", show_default=True, help="Reverse-diffusion sampler")
 @click.option("--scale-pow", type=float, default=4.0, show_default=True, help="Power for cosine CFG schedule (256)")
 @click.option("--vae-decoder", type=click.Choice(["ema", "mse"]), default="ema", show_default=True, help="VAE decoder variant")
 @click.option("--decode-layer", type=int, default=None, help="Decode layer override")
@@ -402,7 +406,7 @@ def generate_images(
     class_idx,
     cfg_scale,
     num_sampling_steps,
-    use_ddim,
+    sampler,
     scale_pow,
     vae_decoder,
     decode_layer,
@@ -468,8 +472,10 @@ def generate_images(
     print(f"Model loaded: {msg}")
     del state
 
+    # DPM-Solver++ subsamples the full 1000-step schedule itself; DDIM/DDPM use a
+    # spaced schedule whose num_timesteps == num_sampling_steps.
     diff_config = diffusion_defaults()
-    diff_config["timestep_respacing"] = str(num_sampling_steps)
+    diff_config["timestep_respacing"] = "" if sampler == "dpm++" else str(num_sampling_steps)
     diffusion = create_diffusion(**diff_config)
     diffusion_steps = diff_config["diffusion_steps"]
 
@@ -549,7 +555,8 @@ def generate_images(
                         model, vae, diffusion, dev, latent_size, num_classes,
                         bs, class_labels, gen,
                         cfg_scale=cfg_scale, scale_pow=scale_pow,
-                        diffusion_steps=diffusion_steps, use_ddim=use_ddim,
+                        diffusion_steps=diffusion_steps, sampler=sampler,
+                        num_sampling_steps=num_sampling_steps,
                     )
 
                     if save_mode == "hdf5":
@@ -580,7 +587,8 @@ def generate_images(
                         model, vae, diffusion, dev, latent_size, num_classes,
                         batch_sz, class_labels, gen,
                         cfg_scale=cfg_scale, scale_pow=scale_pow,
-                        diffusion_steps=diffusion_steps, use_ddim=use_ddim,
+                        diffusion_steps=diffusion_steps, sampler=sampler,
+                        num_sampling_steps=num_sampling_steps,
                     )
 
                     for i, img in enumerate(imgs):
@@ -622,7 +630,7 @@ def generate_images(
                 "num_classes": int(num_classes),
                 "cfg_scale": float(cfg_scale),
                 "num_sampling_steps": int(num_sampling_steps),
-                "use_ddim": bool(use_ddim),
+                "sampler": sampler,
             },
         )
         size_mb = merged_path.stat().st_size / (1024 * 1024)

--- a/scripts/sample.py
+++ b/scripts/sample.py
@@ -25,6 +25,7 @@ import diffit.diffit as diffit_module
 from diffit import create_diffusion, diffusion_defaults
 from diffit.constants import PIXEL_NORM_HALF, UINT8_MAX, VAE_SCALE_FACTOR
 from diffit.dist_util import dev, get_rank, get_world_size, load_state_dict, setup_dist
+from diffit.metrics import sample_latents
 
 
 @click.command()
@@ -38,7 +39,7 @@ from diffit.dist_util import dev, get_rank, get_world_size, load_state_dict, set
 @click.option("--cfg-scale", type=float, default=4.4, show_default=True, help="Classifier-free guidance scale")
 @click.option("--cfg-cond/--no-cfg-cond", default=True, show_default=True, help="Use classifier-free guidance")
 @click.option("--class-cond/--no-class-cond", default=True, show_default=True, help="Use class conditioning")
-@click.option("--use-ddim/--no-use-ddim", default=False, show_default=True, help="Use DDIM sampling")
+@click.option("--sampler", type=click.Choice(["dpm++", "ddim", "ddpm"]), default="ddim", show_default=True, help="Reverse-diffusion sampler")
 @click.option("--scale-pow", type=float, default=4.0, show_default=True, help="Power for cosine CFG schedule (256 only)")
 @click.option("--vae-decoder", type=click.Choice(["ema", "mse"]), default="ema", show_default=True, help="VAE decoder variant")
 @click.option("--decode-layer", type=int, default=None, help="Decode layer override")
@@ -55,7 +56,7 @@ def generate_samples(
     cfg_scale,
     cfg_cond,
     class_cond,
-    use_ddim,
+    sampler,
     scale_pow,
     vae_decoder,
     decode_layer,
@@ -81,9 +82,10 @@ def generate_samples(
     msg = model.load_state_dict(load_state_dict(model_path, map_location="cpu"))
     print(f"Model loaded: {msg}")
 
-    # Create diffusion
+    # Create diffusion. DPM-Solver++ subsamples the full 1000-step schedule itself;
+    # DDIM/DDPM use a spaced schedule whose num_timesteps == num_sampling_steps.
     diff_config = diffusion_defaults()
-    diff_config["timestep_respacing"] = str(num_sampling_steps)
+    diff_config["timestep_respacing"] = "" if sampler == "dpm++" else str(num_sampling_steps)
     diffusion = create_diffusion(**diff_config)
 
     model.to(dev())
@@ -122,15 +124,16 @@ def generate_samples(
             else:
                 model_kwargs["y"] = classes
 
-            sample_fn = diffusion.ddim_sample_loop if use_ddim else diffusion.p_sample_loop
-            sample = sample_fn(
+            sample = sample_latents(
                 model.forward_with_cfg,
+                diffusion,
                 z.shape,
-                z,
-                clip_denoised=False,
-                progress=(get_rank() == 0),
+                dev(),
+                sampler=sampler,
+                num_steps=num_sampling_steps,
                 model_kwargs=model_kwargs,
-                device=dev(),
+                noise=z,
+                progress=(get_rank() == 0),
             )
 
             if cfg_cond:

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -39,13 +39,13 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 import diffit.diffit as diffit_module
 from diffit import create_diffusion, diffusion_defaults, logger
 from diffit.constants import PIXEL_NORM_HALF, UINT8_MAX, VAE_SCALE_FACTOR
-from diffit.dpm_solver import dpm_solver_sample
 from diffit.image_datasets import count_data, load_data
 from diffit.inception import InceptionFeatureExtractor
 from diffit.metrics import (
     HAS_COMBRA,
     compute_activations,
     evaluate_metrics,
+    sample_latents,
 )
 from diffit.nn import update_ema
 from diffit.timestep_sampler import create_named_schedule_sampler
@@ -88,7 +88,7 @@ def setup_snapshot_image_grid(image_size, gw=None, gh=None):
 def generate_snapshot_images(
     ema_model, vae, diffusion, grid_z, grid_classes, batch_gpu, device,
     *,
-    cfg_scale, null_class_idx, num_sampling_steps=25, scale_pow=4.0,
+    cfg_scale, null_class_idx, num_sampling_steps=25, scale_pow=4.0, sampler="dpm++",
 ):
     """Generate a batch of images from the EMA model for snapshot grids."""
     all_samples = []
@@ -103,11 +103,12 @@ def generate_snapshot_images(
             "scale_pow": scale_pow,
         }
         with torch.amp.autocast("cuda", dtype=torch.float16):
-            sample = dpm_solver_sample(
+            sample = sample_latents(
                 ema_model.forward_with_cfg,
                 diffusion,
                 z_cfg.shape,
                 device,
+                sampler=sampler,
                 num_steps=num_sampling_steps,
                 model_kwargs=model_kwargs,
                 noise=z_cfg,
@@ -181,6 +182,8 @@ def training_loop(
     workers=4,
     cache_in_ram=False,
     num_fid_samples=10000,
+    eval_sampler="ddim",
+    eval_sampling_steps=100,
     **_extra,
 ):
     """Main training loop for DiffiT."""
@@ -257,6 +260,14 @@ def training_loop(
     diff_config = diffusion_defaults()
     diffusion = create_diffusion(**diff_config)
     schedule_sampler = create_named_schedule_sampler(schedule_sampler_name, diffusion)
+
+    # Diffusion the eval/snapshot sampler runs on. DPM-Solver++ subsamples the full
+    # 1000-step schedule itself, so it reuses `diffusion`; DDIM/DDPM use the native
+    # loops on a spaced schedule whose num_timesteps == eval_sampling_steps.
+    if eval_sampler == "dpm++":
+        eval_diffusion = diffusion
+    else:
+        eval_diffusion = create_diffusion(**{**diff_config, "timestep_respacing": str(eval_sampling_steps)})
 
     # Optimizer — fused=True keeps param updates in a single CUDA kernel
     # and is ~15-20 % faster than the default loop on Ampere / Hopper.
@@ -446,10 +457,11 @@ def training_loop(
     # Save initial fakes
     if is_main:
         fakes_init = generate_snapshot_images(
-            ema_model, vae, diffusion, grid_z, grid_classes,
+            ema_model, vae, eval_diffusion, grid_z, grid_classes,
             batch_gpu=batch_gpu, device=device,
             cfg_scale=cfg_scale,
             null_class_idx=num_dataset_classes,
+            sampler=eval_sampler, num_sampling_steps=eval_sampling_steps,
         )
         save_image_grid(fakes_init, os.path.join(run_dir, "fakes_init.png"), drange=[0, 255], grid_size=grid_size)
 
@@ -626,10 +638,11 @@ def training_loop(
                 if is_main:
                     logger.log(f"Saving image snapshot (kimg={cur_nimg / 1e3:.1f})...")
                     fakes = generate_snapshot_images(
-                        ema_model, vae, diffusion, grid_z, grid_classes,
+                        ema_model, vae, eval_diffusion, grid_z, grid_classes,
                         batch_gpu=batch_gpu, device=device,
                         cfg_scale=cfg_scale,
                         null_class_idx=num_dataset_classes,
+                        sampler=eval_sampler, num_sampling_steps=eval_sampling_steps,
                     )
                     save_image_grid(
                         fakes, os.path.join(run_dir, f"fakes{cur_nimg // 1000:06d}.png"),
@@ -640,9 +653,10 @@ def training_loop(
                 # Evaluate quality metrics (ALL ranks generate samples)
                 if num_fid_samples > 0:
                     stats_metrics = evaluate_metrics(
-                        ema_model, vae, diffusion, ref_acts, inception_extractor,
+                        ema_model, vae, eval_diffusion, ref_acts, inception_extractor,
                         num_fid_samples, batch_gpu, latent_size, device,
                         cfg_scale=cfg_scale,
+                        sampler=eval_sampler, num_sampling_steps=eval_sampling_steps,
                         rank=rank, world_size=num_gpus,
                         log_fn=logger.log,
                         class_list=list(range(num_dataset_classes)),
@@ -681,10 +695,11 @@ def training_loop(
         # Final image snapshot
         logger.log("Saving final image snapshot...")
         fakes = generate_snapshot_images(
-            ema_model, vae, diffusion, grid_z, grid_classes,
+            ema_model, vae, eval_diffusion, grid_z, grid_classes,
             batch_gpu=batch_gpu, device=device,
             cfg_scale=cfg_scale,
             null_class_idx=num_dataset_classes,
+            sampler=eval_sampler, num_sampling_steps=eval_sampling_steps,
         )
         save_image_grid(
             fakes, os.path.join(run_dir, f"fakes{cur_nimg // 1000:06d}.png"),
@@ -784,6 +799,8 @@ class TrainConfig:
     use_fp16: bool = True
     schedule_sampler_name: str = "uniform"
     num_fid_samples: int = 10000
+    eval_sampler: str = "ddim"
+    eval_sampling_steps: int = 100
     grad_accum_steps: int = 1
     gradient_checkpointing: bool = False
     lr_warmup_kimg: int = 0
@@ -828,6 +845,8 @@ BASE_CONFIGS = {
 @click.option("--schedule-sampler", "schedule_sampler_name", help="Timestep sampler [default: from cfg]", type=str, default=None)
 @click.option("--num-fid-samples", help="Samples for FID eval during training (0=disable)", metavar="INT", type=click.IntRange(min=0), default=None)
 @click.option("--cfg-scale",    help="Classifier-free guidance scale used during training-time eval [default: from cfg]", metavar="FLOAT", type=float, default=None)
+@click.option("--eval-sampler", help="Sampler for training-time eval/snapshots [default: ddim]", type=click.Choice(["dpm++", "ddim", "ddpm"]), default=None)
+@click.option("--eval-sampling-steps", help="Eval sampler steps [default: dpm++=25, ddim=100, ddpm=250]", metavar="INT", type=click.IntRange(min=1), default=None)
 
 # Performance tuning.
 @click.option("--grad-accum",  help="Gradient accumulation steps (effective batch = batch-gpu × gpus × accum)", metavar="INT", type=click.IntRange(min=1), default=None)
@@ -871,6 +890,14 @@ def main(**kwargs):
         overrides["num_fid_samples"] = opts["num_fid_samples"]
     if opts["cfg_scale"] is not None:
         overrides["cfg_scale"] = opts["cfg_scale"]
+    if opts["eval_sampler"] is not None:
+        overrides["eval_sampler"] = opts["eval_sampler"]
+    # Resolve eval step count: explicit flag wins, else a sensible per-sampler default.
+    resolved_eval_sampler = opts["eval_sampler"] or BASE_CONFIGS[opts["cfg"]].eval_sampler
+    if opts["eval_sampling_steps"] is not None:
+        overrides["eval_sampling_steps"] = opts["eval_sampling_steps"]
+    else:
+        overrides["eval_sampling_steps"] = {"dpm++": 25, "ddim": 100, "ddpm": 250}[resolved_eval_sampler]
     if opts["grad_accum"] is not None:
         overrides["grad_accum_steps"] = opts["grad_accum"]
     if opts["gradient_checkpointing"] is not None:
@@ -904,6 +931,8 @@ def main(**kwargs):
         cache_in_ram=opts["cache_in_ram"],
         num_fid_samples=cfg.num_fid_samples,
         cfg_scale=cfg.cfg_scale,
+        eval_sampler=cfg.eval_sampler,
+        eval_sampling_steps=cfg.eval_sampling_steps,
         grad_accum_steps=cfg.grad_accum_steps,
         gradient_checkpointing=cfg.gradient_checkpointing,
         lr_warmup_kimg=cfg.lr_warmup_kimg,

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -40,7 +40,7 @@ import diffit.diffit as diffit_module
 from diffit import create_diffusion, diffusion_defaults, logger
 from diffit.constants import PIXEL_NORM_HALF, UINT8_MAX, VAE_SCALE_FACTOR
 from diffit.dpm_solver import dpm_solver_sample
-from diffit.image_datasets import load_data
+from diffit.image_datasets import count_data, load_data
 from diffit.inception import InceptionFeatureExtractor
 from diffit.metrics import (
     HAS_COMBRA,
@@ -246,6 +246,12 @@ def training_loop(
     ema_model = copy.deepcopy(model)
     ema_model.requires_grad_(False)
     ema_model.eval()
+    # Speed up reverse-diffusion sampling: the training model is compiled below,
+    # but the EMA model used for snapshot/eval sampling is not. Compile its
+    # sampling entry point in place. Safe because update_ema updates EMA params
+    # in place (mul_/add_), so tensor identity is preserved and the compiled
+    # graph stays valid across EMA steps.
+    ema_model.forward_with_cfg = torch.compile(ema_model.forward_with_cfg)
 
     # Create diffusion
     diff_config = diffusion_defaults()
@@ -333,6 +339,17 @@ def training_loop(
     grid_size = (gw, gh)
     n_grid = gw * gh
 
+    # When combra is installed, evaluate on the WHOLE training dataset: the
+    # reference is every real image once and we generate a matching number of
+    # samples. Without combra the eval path is unchanged (configured
+    # num_fid_samples, e.g. the 10k default). Computed on all ranks so the
+    # distributed eval generation agrees on the sample count.
+    full_dataset_eval = HAS_COMBRA and num_fid_samples > 0
+    if full_dataset_eval:
+        num_fid_samples = count_data(data)
+        if is_main:
+            logger.log(f"combra installed → evaluating on whole dataset ({num_fid_samples} images).")
+
     # --- Load Inception model + pre-compute reference features (rank 0 only) ---
     inception_extractor = None
     ref_acts = None
@@ -345,10 +362,13 @@ def training_loop(
         inception_extractor = InceptionFeatureExtractor(inception_model)
 
         logger.log(f"Pre-computing reference Inception features ({num_fid_samples} real images)...")
+        # Full-dataset mode walks the dataset once deterministically (no shuffle,
+        # keep the final partial batch) so every real image is used exactly once.
         ref_iter = load_data(
             data_dir=data, batch_size=min(num_fid_samples, 64), image_size=image_size,
             class_cond=True, random_flip=False, num_workers=workers,
             distributed=False,
+            deterministic=full_dataset_eval, drop_last=not full_dataset_eval,
         )
         ref_images = []
         n_collected = 0


### PR DESCRIPTION
## Summary
This PR adds support for configurable reverse-diffusion samplers (DPM++, DDIM, DDPM) during training-time evaluation and snapshot generation, replacing the hardcoded DPM-Solver++ approach. It also introduces full-dataset evaluation mode when COMBRA is available.

## Key Changes

- **Sampler abstraction**: Introduced `sample_latents()` function in `diffit/metrics.py` that dispatches to the appropriate sampler (DPM++, DDIM, or DDPM) based on configuration. This replaces direct calls to `dpm_solver_sample()`.

- **Training configuration**: Added `eval_sampler` and `eval_sampling_steps` parameters to `TrainConfig` with sensible defaults (DDIM with 100 steps). CLI options allow overriding these values with per-sampler step defaults (dpm++=25, ddim=100, ddpm=250).

- **Diffusion schedule handling**: Different samplers require different diffusion configurations:
  - DPM-Solver++ reuses the full 1000-step schedule
  - DDIM/DDPM use a spaced schedule with `num_timesteps == eval_sampling_steps`
  - Created separate `eval_diffusion` object when needed

- **Full-dataset evaluation**: When COMBRA is installed, evaluation automatically uses the entire training dataset as reference (via new `count_data()` function) instead of a fixed sample count. Dataset loading is configured to be deterministic and not drop the final partial batch.

- **EMA model compilation**: Added `torch.compile()` to the EMA model's `forward_with_cfg` method to accelerate reverse-diffusion sampling during evaluation.

- **Script updates**: Updated `scripts/gen_images.py` and `scripts/sample.py` to use the new `sample_latents()` abstraction and support sampler selection via CLI.

## Implementation Details

- The `sample_latents()` function handles the dispatch logic: DPM++ uses its own subsampling of the full schedule, while DDIM/DDPM use native loops on pre-spaced schedules.
- Eval sampling is now consistently parameterized across snapshot generation, metric evaluation, and standalone scripts.
- The `drop_last` parameter in `load_data()` is now configurable to support full-dataset evaluation modes.

https://claude.ai/code/session_01KY2mLeedmeuuX6btm3QmuY