### PR TITLE
Port san-v2 training/infra improvements into DiffiT-v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,16 @@ This caches the following models locally:
 - **stabilityai/sd-vae-ft-ema** (335 MB) — VAE for latent diffusion (`~/.cache/huggingface/`)
 - **stabilityai/sd-vae-ft-mse** (335 MB) — VAE variant for `diffit-gen-images --vae-decoder mse`
 - **InceptionV3** (104 MB) — for IS/FID metrics during training (`~/.cache/torch/hub/`)
+- **combra backbones** (InceptionV3-FID / CLIP / DINOv2) — only when the optional `combra` package is installed, for `--combra-metrics`
+
+Alternatively, for fully offline nodes without a Python environment, a pure
+`wget`/`curl`/`git` variant fetches the torch-hub / CLIP weights directly into the
+caches (and the VAEs via `huggingface-cli` when present):
+
+```bash
+bash download_models.sh                         # caches under ~/.cache
+MODEL_CACHE=/shared/team/caches bash download_models.sh
+```
 
 > If your compute nodes use a shared filesystem with the login node, the cached files will be available automatically. Otherwise, ensure `~/.cache/huggingface/` and `~/.cache/torch/hub/` are synced.
 
@@ -305,6 +315,22 @@ diffit-train --outdir=./training-runs \
     --resume ./training-runs/00000-diffit-256-gpus2-batch192/network-snapshot-001000.pt
 ```
 
+### Hydra entry point (optional)
+
+`train_hydra.py` is a thin wrapper over the same training code, for users who
+prefer Hydra/YAML config management. It derives every default by introspecting
+the `train.py` click options (single source of truth), so `configs/config.yaml`
+only declares the required fields and any new flag propagates automatically:
+
+```bash
+python train_hydra.py outdir=./training-runs cfg=diffit-256 \
+    data=./datasets/imagenet_256x256.zip gpus=2 batch_gpu=42 \
+    combra_metrics=false save_inference_only=true snap=100
+```
+
+Override any `train.py` option by its Python name (dashes → underscores). Both
+entry points call the same `launch_from_opts`, so runs are identical.
+
 ### Training options
 
 | Option | Default | Description |
@@ -328,6 +354,8 @@ diffit-train --outdir=./training-runs \
 | `--schedule-sampler` | from cfg | Timestep sampler override |
 | `--cfg-scale` | from cfg | CFG scale used during training-time eval |
 | `--num-fid-samples` | from cfg (10000) | Samples for FID/IS eval during training (0=disable) |
+| `--combra-metrics` | true | Compute combra generative-quality metrics each snapshot tick (independent of `--num-fid-samples`); warns if requested but combra is not installed |
+| `--save-inference-only` | false | Also write a small `network-snapshot-<kimg>-inference.pt` (EMA weights only, no optimizer/resume state) each snapshot tick — the smallest artifact for `gen_images.py` / `sample.py` |
 | `--grad-accum` | from cfg | Gradient accumulation steps (effective batch = batch-gpu × gpus × accum) |
 | `--grad-ckpt / --no-grad-ckpt` | from cfg | Toggle gradient checkpointing (trades compute for memory) |
 | `--lr-warmup` | from cfg | Linear LR warmup duration in kimg (0 = disabled) |
@@ -353,13 +381,20 @@ training-runs/00000-diffit-256-gpus4-batch256/
 ├── fakes000200.png               # Generated images at 200 kimg
 ├── fakes000400.png               # Generated images at 400 kimg
 ├── ...
-├── network-snapshot-001000.pt    # Periodic checkpoint
+├── network-snapshot-001000.pt    # Periodic checkpoint (full resumable state)
+├── network-snapshot-001000-inference.pt  # (only with --save-inference-only) EMA weights only
 ├── network-snapshot-002000.pt
 ├── ...
-└── network-final.pt              # Final trained model
+└── network-final.pt              # Final trained model (full resumable state)
 ```
 
-Quality metrics (**IS**, **FID**, **sFID**, **Precision**, **Recall**) are computed automatically every `snap` ticks during training using 10000 samples by default (configurable per `--cfg`). Results are logged to TensorBoard under `Metrics/` and to `stats.jsonl`. Adjust with `--num-fid-samples` (set to 0 to disable).
+`network-snapshot-*.pt` / `network-final.pt` hold the **full** resumable state
+(`model`, `ema`, `opt`, optional `scaler`, `cur_nimg`) so `--resume` can continue
+training exactly. The inference loaders (`gen_images.py`, `sample.py`) transparently
+extract the EMA weights from any of these — a full checkpoint, an older bare
+EMA `state_dict`, or a `--save-inference-only` `*-inference.pt` file.
+
+Quality metrics (**IS**, **FID**, **sFID**, **Precision**, **Recall**) are computed automatically every `snap` ticks during training using 10000 samples by default (configurable per `--cfg`). Results are logged to TensorBoard under `Metrics/` and to `stats.jsonl`. Adjust with `--num-fid-samples` (set to 0 to disable). When the optional `combra` package is installed (`pip install -e ".[combra]"`) and `--combra-metrics` is on (default), additional `combra_*` metrics (e.g. CMMD, FD-DINOv2) are logged each tick too — and the eval reference becomes the whole training set. Pre-fetch combra's CLIP/DINOv2 backbones for offline nodes with `python scripts/download_models.py` or `bash download_models.sh`.
 
 Monitor training with TensorBoard:
 

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -1,0 +1,22 @@
+# Hydra config for DiffiT training. Defaults for every option come from the
+# train.py click CLI (see train_hydra.py), so this file only declares the
+# required fields; override any other train.py option here or on the command
+# line by its Python name (e.g. `combra_metrics=false`, `save_inference_only=true`).
+defaults:
+  - _self_
+
+# Required (no default in the CLI either -- must be provided here or on the
+# command line).
+outdir: ???
+cfg: ???
+data: ???
+gpus: ???
+batch_gpu: ???
+
+# Keep the working directory at the repo root so relative --data / --outdir
+# paths behave exactly like the click CLI.
+hydra:
+  job:
+    chdir: false
+  run:
+    dir: .

--- a/diffit/dist_util.py
+++ b/diffit/dist_util.py
@@ -107,6 +107,24 @@ def load_state_dict(path, **kwargs):
     return th.load(path, **kwargs)
 
 
+def extract_inference_state_dict(obj):
+    """Return the inference (EMA) weights from anything ``load_state_dict`` yields.
+
+    Training writes full resumable checkpoints ``{"model", "ema", "opt", ...}``
+    by default, plus optional EMA-only inference snapshots. Older snapshots were
+    a bare ``state_dict``. This normalises all three so inference loaders
+    (gen_images.py, sample.py) get a plain weights dict regardless of source:
+    prefer EMA weights, fall back to the raw model, else assume it already is a
+    state_dict.
+    """
+    if isinstance(obj, dict):
+        if "ema" in obj:
+            return obj["ema"]
+        if "model" in obj:
+            return obj["model"]
+    return obj
+
+
 def sync_params(params):
     """Synchronize a sequence of Tensors across ranks from rank 0."""
     for p in params:

--- a/download_models.sh
+++ b/download_models.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Pure-shell prefetch of every pretrained weight DiffiT training + the combra
+# metrics need, straight into the caches the libraries look in -- no GPU
+# required. Run on a node WITH internet (e.g. a login node); the weights cache
+# under $HOME, shared with the offline compute nodes, so the training jobs then
+# need no network.
+#
+# Two cache families are populated:
+#   * torch.hub / clip caches  -- via plain wget/curl/git (combra backbones +
+#     the torchvision InceptionV3 used for inline FID/IS).
+#   * HuggingFace cache        -- the two SD-VAE decoders, via huggingface-cli
+#     (falls back to `python scripts/download_models.py` if the CLI is absent).
+#
+# URLs and on-disk filenames are pinned to what the installed libraries expect
+# (pytorch-fid, open_clip 'openai', torch.hub dinov2, torchvision inception).
+#
+# Usage:
+#   bash download_models.sh                      # caches under $HOME/.cache (defaults)
+#   MODEL_CACHE=/shared/team/caches bash download_models.sh
+set -u
+
+MODEL_CACHE="${MODEL_CACHE:-$HOME/.cache}"
+HUB_CKPT="${MODEL_CACHE}/torch/hub/checkpoints"   # torchvision + pytorch-fid + dinov2 weights
+HUB_DIR="${MODEL_CACHE}/torch/hub"                # torch.hub repo code (dinov2)
+CLIP_DIR="${MODEL_CACHE}/clip"                    # open_clip 'openai' weights
+mkdir -p "$HUB_CKPT" "$HUB_DIR" "$CLIP_DIR"
+
+if ! command -v wget >/dev/null 2>&1 && ! command -v curl >/dev/null 2>&1; then
+    echo "ERROR: need wget or curl on PATH." >&2
+    exit 1
+fi
+
+status=0
+fetch() {  # fetch <url> <dest>
+    local url="$1" dest="$2"
+    if [[ -s "$dest" ]]; then
+        echo "  exists: ${dest##*/}"
+        return 0
+    fi
+    echo "  downloading: ${url##*/}"
+    if command -v wget >/dev/null 2>&1; then
+        wget -c -O "$dest" "$url" || { echo "  FAILED: $url"; rm -f "$dest"; status=1; return 1; }
+    else
+        curl -fL -o "$dest" "$url" || { echo "  FAILED: $url"; rm -f "$dest"; status=1; return 1; }
+    fi
+}
+
+echo "Caching pretrained models under: $MODEL_CACHE"
+
+echo; echo "[1/4] torchvision InceptionV3 (inline FID/IS during training) -> $HUB_CKPT"
+fetch "https://download.pytorch.org/models/inception_v3_google-0cc3c7bd.pth" "$HUB_CKPT/inception_v3_google-0cc3c7bd.pth"
+
+echo; echo "[2/4] InceptionV3 FID weights (combra fid) -> $HUB_CKPT"
+fetch "https://github.com/mseitzer/pytorch-fid/releases/download/fid_weights/pt_inception-2015-12-05-6726825d.pth" "$HUB_CKPT/pt_inception-2015-12-05-6726825d.pth"
+
+echo; echo "[3/4] CLIP ViT-L-14-336 'openai' (combra cmmd) -> $CLIP_DIR"
+fetch "https://openaipublic.azureedge.net/clip/models/3035c92b350959924f9f00213499208652fc7ea050643e8b385c2dac08641f02/ViT-L-14-336px.pt" "$CLIP_DIR/ViT-L-14-336px.pt"
+
+echo; echo "[4/4] DINOv2 dinov2_vitb14 (combra fd_dinov2) -> $HUB_DIR"
+fetch "https://dl.fbaipublicfiles.com/dinov2/dinov2_vitb14/dinov2_vitb14_pretrain.pth" "$HUB_CKPT/dinov2_vitb14_pretrain.pth"
+# torch.hub also needs the dinov2 model code (it normally fetches the repo itself).
+if [[ -d "$HUB_DIR/facebookresearch_dinov2_main" ]]; then
+    echo "  exists: facebookresearch_dinov2_main/"
+elif command -v git >/dev/null 2>&1; then
+    echo "  cloning facebookresearch/dinov2"
+    git clone --depth 1 https://github.com/facebookresearch/dinov2 "$HUB_DIR/facebookresearch_dinov2_main" \
+        || { echo "  FAILED: git clone dinov2"; status=1; }
+else
+    echo "  SKIPPED dinov2 repo: git not on PATH"; status=1
+fi
+
+# --- SD-VAE decoders (HuggingFace cache) ---------------------------------
+# These live in the HF cache (snapshots/blobs layout), so use huggingface-cli
+# when available; otherwise fall back to the Python downloader which uses the
+# diffusers/HF hub client directly.
+echo; echo "[VAE] stabilityai/sd-vae-ft-ema + sd-vae-ft-mse -> HuggingFace cache"
+if command -v huggingface-cli >/dev/null 2>&1; then
+    for repo in stabilityai/sd-vae-ft-ema stabilityai/sd-vae-ft-mse; do
+        echo "  downloading: $repo"
+        huggingface-cli download "$repo" >/dev/null \
+            || { echo "  FAILED: $repo"; status=1; }
+    done
+else
+    echo "  huggingface-cli not found -- fetch the VAEs with:"
+    echo "      python scripts/download_models.py"
+fi
+
+echo
+if [[ $status -eq 0 ]]; then
+    echo "Done. All weights cached under $MODEL_CACHE (+ HuggingFace cache for the VAEs)."
+else
+    echo "Some downloads failed (see above)."
+fi
+exit $status

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "tensorboard>=2.14.0",
     "psutil>=5.9.0",
     "h5py>=3.8.0",
+    "hydra-core>=1.3",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,6 @@ h5py>=3.8.0
 scipy>=1.10.0,<=1.14.1
 accelerate>=0.27.2
 tensorboard>=2.14.0
+hydra-core>=1.3
 psutil>=5.9.0
 pytest>=7.0.0

--- a/sbatch/h200/h200_train_2_gpu_1024x1024.sbatch
+++ b/sbatch/h200/h200_train_2_gpu_1024x1024.sbatch
@@ -1,0 +1,44 @@
+#!/bin/bash
+#SBATCH --job-name=DiffiT-1024
+#SBATCH --gpus=2
+#SBATCH --cpus-per-task=16
+#SBATCH --time=3-0:0
+#SBATCH --nodes=1
+#SBATCH --partition=rocky
+
+# Self-contained: submittable from anywhere (e.g. the sbatch/ folder). Resolve
+# the repo root (the dir containing pyproject.toml) and cd into it so the
+# relative --data / --outdir paths below resolve consistently.
+SCRIPT_DIR="$(cd "$(dirname "${SLURM_JOB_SCRIPT:-${BASH_SOURCE[0]}}")" && pwd)"
+REPO_DIR="${SLURM_SUBMIT_DIR:-$SCRIPT_DIR}"
+while [[ ! -f "$REPO_DIR/pyproject.toml" && "$REPO_DIR" != / ]]; do
+    REPO_DIR="$(dirname "$REPO_DIR")"
+done
+cd "$REPO_DIR" || exit 1
+
+module purge
+module load Python
+conda activate diffit_rocky_51
+
+export CC=/usr/bin/gcc
+export CXX=/usr/bin/g++
+export TORCH_NCCL_ASYNC_ERROR_HANDLING=1
+export NCCL_DEBUG=INFO
+export TORCH_CUDA_ARCH_LIST="9.0"
+export CUDA_VISIBLE_DEVICES=0,1
+export TORCH_EXTENSIONS_DIR="${HOME}/.cache/torch_extensions"
+export CUDA_CACHE_PATH="${HOME}/.cache/cuda_cache"
+
+nvidia-smi
+
+# DiffiT is pure PyTorch (no custom CUDA-op compilation), so no system CUDA
+# module / CUDA_HOME is required -- the conda env's torch ships its own runtime.
+
+diffit-train --outdir=./runs/diffit_h200_51 \
+        --cfg=diffit-1024 \
+        --data=./datasets/imagenet_1024x1024.zip \
+        --gpus=2 \
+        --batch-gpu 8 \
+        --combra-metrics True \
+        --save-inference-only True \
+        --snap 100

--- a/sbatch/h200/h200_train_2_gpu_256x256.sbatch
+++ b/sbatch/h200/h200_train_2_gpu_256x256.sbatch
@@ -1,0 +1,44 @@
+#!/bin/bash
+#SBATCH --job-name=DiffiT-256
+#SBATCH --gpus=2
+#SBATCH --cpus-per-task=16
+#SBATCH --time=3-0:0
+#SBATCH --nodes=1
+#SBATCH --partition=rocky
+
+# Self-contained: submittable from anywhere (e.g. the sbatch/ folder). Resolve
+# the repo root (the dir containing pyproject.toml) and cd into it so the
+# relative --data / --outdir paths below resolve consistently.
+SCRIPT_DIR="$(cd "$(dirname "${SLURM_JOB_SCRIPT:-${BASH_SOURCE[0]}}")" && pwd)"
+REPO_DIR="${SLURM_SUBMIT_DIR:-$SCRIPT_DIR}"
+while [[ ! -f "$REPO_DIR/pyproject.toml" && "$REPO_DIR" != / ]]; do
+    REPO_DIR="$(dirname "$REPO_DIR")"
+done
+cd "$REPO_DIR" || exit 1
+
+module purge
+module load Python
+conda activate diffit_rocky_51
+
+export CC=/usr/bin/gcc
+export CXX=/usr/bin/g++
+export TORCH_NCCL_ASYNC_ERROR_HANDLING=1
+export NCCL_DEBUG=INFO
+export TORCH_CUDA_ARCH_LIST="9.0"
+export CUDA_VISIBLE_DEVICES=0,1
+export TORCH_EXTENSIONS_DIR="${HOME}/.cache/torch_extensions"
+export CUDA_CACHE_PATH="${HOME}/.cache/cuda_cache"
+
+nvidia-smi
+
+# DiffiT is pure PyTorch (no custom CUDA-op compilation), so no system CUDA
+# module / CUDA_HOME is required -- the conda env's torch ships its own runtime.
+
+diffit-train --outdir=./runs/diffit_h200_51 \
+        --cfg=diffit-256 \
+        --data=./datasets/imagenet_256x256.zip \
+        --gpus=2 \
+        --batch-gpu 42 \
+        --combra-metrics True \
+        --save-inference-only True \
+        --snap 100

--- a/sbatch/h200/h200_train_2_gpu_512x512.sbatch
+++ b/sbatch/h200/h200_train_2_gpu_512x512.sbatch
@@ -1,0 +1,44 @@
+#!/bin/bash
+#SBATCH --job-name=DiffiT-512
+#SBATCH --gpus=2
+#SBATCH --cpus-per-task=16
+#SBATCH --time=3-0:0
+#SBATCH --nodes=1
+#SBATCH --partition=rocky
+
+# Self-contained: submittable from anywhere (e.g. the sbatch/ folder). Resolve
+# the repo root (the dir containing pyproject.toml) and cd into it so the
+# relative --data / --outdir paths below resolve consistently.
+SCRIPT_DIR="$(cd "$(dirname "${SLURM_JOB_SCRIPT:-${BASH_SOURCE[0]}}")" && pwd)"
+REPO_DIR="${SLURM_SUBMIT_DIR:-$SCRIPT_DIR}"
+while [[ ! -f "$REPO_DIR/pyproject.toml" && "$REPO_DIR" != / ]]; do
+    REPO_DIR="$(dirname "$REPO_DIR")"
+done
+cd "$REPO_DIR" || exit 1
+
+module purge
+module load Python
+conda activate diffit_rocky_51
+
+export CC=/usr/bin/gcc
+export CXX=/usr/bin/g++
+export TORCH_NCCL_ASYNC_ERROR_HANDLING=1
+export NCCL_DEBUG=INFO
+export TORCH_CUDA_ARCH_LIST="9.0"
+export CUDA_VISIBLE_DEVICES=0,1
+export TORCH_EXTENSIONS_DIR="${HOME}/.cache/torch_extensions"
+export CUDA_CACHE_PATH="${HOME}/.cache/cuda_cache"
+
+nvidia-smi
+
+# DiffiT is pure PyTorch (no custom CUDA-op compilation), so no system CUDA
+# module / CUDA_HOME is required -- the conda env's torch ships its own runtime.
+
+diffit-train --outdir=./runs/diffit_h200_51 \
+        --cfg=diffit-512 \
+        --data=./datasets/imagenet_512x512.zip \
+        --gpus=2 \
+        --batch-gpu 25 \
+        --combra-metrics True \
+        --save-inference-only True \
+        --snap 100

--- a/scripts/download_models.py
+++ b/scripts/download_models.py
@@ -103,7 +103,7 @@ def download_models():
 
     # --- VAE (EMA variant) ---
     print("=" * 60)
-    print("[1/3] Downloading stabilityai/sd-vae-ft-ema ...")
+    print("[1/4] Downloading stabilityai/sd-vae-ft-ema ...")
     print("=" * 60)
     from diffusers.models import AutoencoderKL
 
@@ -112,19 +112,47 @@ def download_models():
 
     # --- VAE (MSE variant, used by gen_images.py --vae-decoder mse) ---
     print("=" * 60)
-    print("[2/3] Downloading stabilityai/sd-vae-ft-mse ...")
+    print("[2/4] Downloading stabilityai/sd-vae-ft-mse ...")
     print("=" * 60)
     AutoencoderKL.from_pretrained("stabilityai/sd-vae-ft-mse")
     print("  -> cached.\n")
 
     # --- InceptionV3 (used by train.py for inline FID/IS evaluation) ---
     print("=" * 60)
-    print("[3/3] Downloading InceptionV3 (torchvision) ...")
+    print("[3/4] Downloading InceptionV3 (torchvision) ...")
     print("=" * 60)
     from torchvision.models import Inception_V3_Weights, inception_v3
 
     inception_v3(weights=Inception_V3_Weights.DEFAULT)
     print("  -> cached.\n")
+
+    # --- combra backbones (CLIP / DINOv2 / pytorch-fid InceptionV3) ---
+    # Only when combra is installed and --combra-metrics is used during training.
+    # Running each metric on a tiny dummy batch triggers the one-time weight
+    # download into the standard torch hub / clip caches.
+    print("=" * 60)
+    print("[4/4] Downloading combra metric backbones (CLIP / DINOv2 / FID) ...")
+    print("=" * 60)
+    try:
+        import importlib
+
+        if importlib.util.find_spec("combra") is None:
+            print("  combra not installed -- skipping (install it to enable combra metrics).\n")
+        else:
+            import numpy as np
+            from combra.metrics import compute_cmmd, compute_fd_dinov2, compute_fid
+
+            dummy = np.random.randint(0, 256, size=(8, 64, 64, 3), dtype=np.uint8)
+            for label, fn in [
+                ("InceptionV3 (fid)", compute_fid),
+                ("CLIP (cmmd)", compute_cmmd),
+                ("DINOv2 (fd_dinov2)", compute_fd_dinov2),
+            ]:
+                print(f"  - {label}")
+                fn(dummy, dummy, device="cpu")
+            print("  -> cached.\n")
+    except Exception as e:
+        print(f"  combra backbone download skipped/failed: {e}\n")
 
     print("All models downloaded successfully.")
     print(f"  HuggingFace cache: {os.path.expanduser('~/.cache/huggingface/')}")

--- a/scripts/gen_images.py
+++ b/scripts/gen_images.py
@@ -58,7 +58,7 @@ from tqdm.auto import tqdm
 import diffit.diffit as diffit_module
 from diffit import create_diffusion, diffusion_defaults
 from diffit.constants import PIXEL_NORM_HALF, UINT8_MAX, VAE_SCALE_FACTOR
-from diffit.dist_util import load_state_dict
+from diffit.dist_util import extract_inference_state_dict, load_state_dict
 from diffit.metrics import sample_latents
 
 
@@ -441,7 +441,7 @@ def generate_images(
     # threads never touch the same model.
     print(f'Loading model from "{model_path}" onto {world_size} device(s)...')
     latent_size = image_size // 8
-    state = load_state_dict(model_path, map_location="cpu")
+    state = extract_inference_state_dict(load_state_dict(model_path, map_location="cpu"))
 
     # Auto-detect num_classes from the checkpoint's class embedding table.
     # Last row is the CFG null token, so subtract 1.

--- a/scripts/sample.py
+++ b/scripts/sample.py
@@ -24,7 +24,14 @@ from diffusers.models import AutoencoderKL
 import diffit.diffit as diffit_module
 from diffit import create_diffusion, diffusion_defaults
 from diffit.constants import PIXEL_NORM_HALF, UINT8_MAX, VAE_SCALE_FACTOR
-from diffit.dist_util import dev, get_rank, get_world_size, load_state_dict, setup_dist
+from diffit.dist_util import (
+    dev,
+    extract_inference_state_dict,
+    get_rank,
+    get_world_size,
+    load_state_dict,
+    setup_dist,
+)
 from diffit.metrics import sample_latents
 
 
@@ -79,7 +86,9 @@ def generate_samples(
     model = diffit_module.__dict__[model_name](
         input_size=latent_size, decode_layer=decode_layer, num_classes=num_classes,
     )
-    msg = model.load_state_dict(load_state_dict(model_path, map_location="cpu"))
+    msg = model.load_state_dict(
+        extract_inference_state_dict(load_state_dict(model_path, map_location="cpu"))
+    )
     print(f"Model loaded: {msg}")
 
     # Create diffusion. DPM-Solver++ subsamples the full 1000-step schedule itself;

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -26,6 +26,7 @@ import os
 import re
 import tempfile
 import time
+import warnings
 from contextlib import nullcontext
 
 import click
@@ -125,6 +126,25 @@ def generate_snapshot_images(
     return images
 
 
+def build_checkpoint(model, ema_model, opt, scaler, use_grad_scaler, cur_nimg):
+    """Assemble a full resumable checkpoint dict (matches the --resume loader).
+
+    Contains the raw model + EMA weights, optimizer state, the GradScaler state
+    (when AMP fp16 is active), and the image counter so training can resume
+    exactly. ``--save-inference-only`` additionally writes a tiny companion file
+    holding only ``ema_model.state_dict()`` for downstream inference.
+    """
+    ckpt = {
+        "model": model.state_dict(),
+        "ema": ema_model.state_dict(),
+        "opt": opt.state_dict(),
+        "cur_nimg": cur_nimg,
+    }
+    if use_grad_scaler:
+        ckpt["scaler"] = scaler.state_dict()
+    return ckpt
+
+
 def subprocess_fn(rank, c, temp_dir):
     """Entry point for each DDP worker."""
     logger.configure(log_dir=c["run_dir"])
@@ -184,6 +204,8 @@ def training_loop(
     num_fid_samples=10000,
     eval_sampler="ddim",
     eval_sampling_steps=100,
+    combra_metrics=True,
+    save_inference_only=False,
     **_extra,
 ):
     """Main training loop for DiffiT."""
@@ -350,22 +372,35 @@ def training_loop(
     grid_size = (gw, gh)
     n_grid = gw * gh
 
-    # When combra is installed, evaluate on the WHOLE training dataset: the
+    # Warn early (once, on rank 0) if combra metrics are requested but the
+    # package is missing, so the user is not left wondering why no combra_*
+    # values ever appear.
+    if combra_metrics and is_main and not HAS_COMBRA:
+        warnings.warn(
+            "--combra-metrics=True but the `combra` package is not installed -- "
+            "combra metrics will be skipped. Install it to enable them, or pass "
+            "--combra-metrics=false to silence this warning."
+        )
+
+    # combra metrics run only when requested AND installed.
+    use_combra = combra_metrics and HAS_COMBRA
+
+    # When combra metrics are active, evaluate on the WHOLE training dataset: the
     # reference is every real image once and we generate a matching number of
-    # samples. Without combra the eval path is unchanged (configured
-    # num_fid_samples, e.g. the 10k default). Computed on all ranks so the
-    # distributed eval generation agrees on the sample count.
-    full_dataset_eval = HAS_COMBRA and num_fid_samples > 0
+    # samples. Otherwise the eval path is unchanged (configured num_fid_samples,
+    # e.g. the 10k default). Computed on all ranks so the distributed eval
+    # generation agrees on the sample count.
+    full_dataset_eval = use_combra and num_fid_samples > 0
     if full_dataset_eval:
         num_fid_samples = count_data(data)
         if is_main:
-            logger.log(f"combra installed → evaluating on whole dataset ({num_fid_samples} images).")
+            logger.log(f"combra metrics enabled → evaluating on whole dataset ({num_fid_samples} images).")
 
     # --- Load Inception model + pre-compute reference features (rank 0 only) ---
     inception_extractor = None
     ref_acts = None
-    combra_ref_images = None  # kept for combra metrics when combra is installed
-    combra_ref_cache = {} if HAS_COMBRA else None
+    combra_ref_images = None  # kept for combra metrics when combra is active
+    combra_ref_cache = {} if use_combra else None
     if is_main and num_fid_samples > 0:
         logger.log("Loading InceptionV3 for metric evaluation...")
         from torchvision.models import Inception_V3_Weights, inception_v3
@@ -390,7 +425,7 @@ def training_loop(
             n_collected += batch_np.shape[0]
         ref_images = np.concatenate(ref_images, axis=0)[:num_fid_samples]
         ref_acts = compute_activations(ref_images, inception_extractor, batch_size=64, device=device)
-        if HAS_COMBRA:
+        if use_combra:
             combra_ref_images = ref_images  # reused as the combra reference batch
         else:
             del ref_images
@@ -677,20 +712,26 @@ def training_loop(
                                 stats_tfevents.add_scalar(f"Metrics/{name}", value, global_step=global_step, walltime=walltime)
                             stats_tfevents.flush()
 
-                # Save checkpoint (rank 0 only) — inference-only: EMA weights as a raw state_dict
+                # Save checkpoint (rank 0 only) — full resumable state by default.
                 if is_main:
                     save_path = os.path.join(run_dir, f"network-snapshot-{cur_nimg // 1000:06d}.pt")
                     logger.log(f"Saving checkpoint to {save_path}...")
-                    torch.save(ema_model.state_dict(), save_path)
+                    torch.save(build_checkpoint(model, ema_model, opt, scaler, use_grad_scaler, cur_nimg), save_path)
+                    if save_inference_only:
+                        inf_path = os.path.join(run_dir, f"network-snapshot-{cur_nimg // 1000:06d}-inference.pt")
+                        torch.save(ema_model.state_dict(), inf_path)
+                        logger.log(f"Inference-only snapshot saved to {inf_path}")
                     logger.log(f"Checkpoint saved (kimg={cur_nimg / 1e3:.1f})")
 
                     maintenance_time = time.time() - snap_start
 
-    # Final save — inference-only: EMA weights as a raw state_dict
+    # Final save — full resumable state by default.
     if is_main:
         save_path = os.path.join(run_dir, "network-final.pt")
         logger.log(f"Saving final model to {save_path}...")
-        torch.save(ema_model.state_dict(), save_path)
+        torch.save(build_checkpoint(model, ema_model, opt, scaler, use_grad_scaler, cur_nimg), save_path)
+        if save_inference_only:
+            torch.save(ema_model.state_dict(), os.path.join(run_dir, "network-final-inference.pt"))
 
         # Final image snapshot
         logger.log("Saving final image snapshot...")
@@ -856,6 +897,8 @@ BASE_CONFIGS = {
 # Misc settings.
 @click.option("--desc",         help="String to include in result dir name", metavar="STR",    type=str, default=None)
 @click.option("--metrics",      help="Quality metrics", metavar="NAME",                        type=str, default="fid50k", show_default=True)
+@click.option("--combra-metrics", help="Compute combra generative-quality metrics each snapshot tick (independent of --metrics)", metavar="BOOL", type=bool, default=True, show_default=True)
+@click.option("--save-inference-only", help="Also write a small inference-only snapshot (EMA weights only, no optimizer/resume state) each snapshot tick", metavar="BOOL", type=bool, default=False, show_default=True)
 @click.option("--tf32/--no-tf32", "allow_tf32", help="Enable TF32 for matmul/conv",            default=True, show_default=True)
 @click.option("--workers",      help="DataLoader worker processes", metavar="INT",             type=click.IntRange(min=1), default=4, show_default=True)
 @click.option("--cache-in-ram/--no-cache-in-ram", help="Cache entire dataset in RAM to reduce disk I/O", default=True, show_default=True)
@@ -863,8 +906,17 @@ BASE_CONFIGS = {
 
 def main(**kwargs):
     """Train DiffiT on class-conditional ImageNet."""
-    opts = kwargs
+    launch_from_opts(kwargs)
 
+
+def launch_from_opts(opts):
+    """Build the run config from a CLI-style opts dict and launch training.
+
+    Shared by the click entry point (``main``) and the Hydra entry point
+    (``train_hydra.py``) so both paths produce identical runs. ``opts`` is a
+    dict keyed by the click option Python names (the same keys click passes to
+    ``main`` as ``**kwargs``).
+    """
     # Start from base configuration, then apply CLI overrides: any explicitly
     # provided option takes precedence. (None means "not provided".)
     overrides = {}
@@ -936,6 +988,8 @@ def main(**kwargs):
         grad_accum_steps=cfg.grad_accum_steps,
         gradient_checkpointing=cfg.gradient_checkpointing,
         lr_warmup_kimg=cfg.lr_warmup_kimg,
+        combra_metrics=opts["combra_metrics"],
+        save_inference_only=opts["save_inference_only"],
         log_interval=10,
         save_interval=10000,
     )

--- a/train_hydra.py
+++ b/train_hydra.py
@@ -1,0 +1,42 @@
+"""Hydra entry point for DiffiT training.
+
+This is a thin wrapper around ``scripts/train.py``: the click CLI there is the
+single source of truth for every option and its default. We introspect those
+click options to seed defaults, overlay whatever ``configs/config.yaml`` (and
+command-line overrides) provide, then hand the merged dict to the same
+``train.launch_from_opts`` the click entry point uses -- so the Hydra and CLI
+paths produce identical runs.
+
+Usage:
+    python train_hydra.py outdir=./runs cfg=diffit-256 \\
+        data=./datasets/imagenet_256x256.zip gpus=2 batch_gpu=42
+
+    # override any train.py option by its Python name (dashes become underscores):
+    python train_hydra.py outdir=./runs cfg=diffit-256 data=... gpus=2 batch_gpu=42 \\
+        combra_metrics=false save_inference_only=true snap=100
+"""
+
+import click
+import hydra
+from omegaconf import DictConfig, OmegaConf
+
+from scripts import train
+
+
+def _cli_defaults():
+    """Default value of every ``train.py`` click option, keyed by its Python name."""
+    return {p.name: p.default for p in train.main.params if isinstance(p, click.Option)}
+
+
+@hydra.main(version_base=None, config_path="configs", config_name="config")
+def main(cfg: DictConfig) -> None:
+    # Start from the CLI defaults, then overlay the resolved Hydra config so any
+    # option the user did not set keeps its train.py default and new flags
+    # propagate automatically.
+    opts = _cli_defaults()
+    opts.update(OmegaConf.to_container(cfg, resolve=True))
+    train.launch_from_opts(opts)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Brings the applicable items from the san-v2 changelog to DiffiT-v2 (a
latent-diffusion model). Architecture-specific san-v2 items (legacy.py
G_ema mirroring, timm 0.4.12 pin, imgui/glfw/ninja removals, CUDA-ops
test relocation, FFHQ removals) do not apply and are intentionally omitted.

- --combra-metrics flag (default true), decoupled from --metrics, with a
  startup warning when combra is requested but not installed.
- --save-inference-only flag and a fix for resume: snapshots/network-final
  now save a full resumable checkpoint (model/ema/opt/scaler/cur_nimg) by
  default, matching the --resume loader; the flag additionally writes a tiny
  EMA-only *-inference.pt. Inference loaders (gen_images.py, sample.py) use a
  new extract_inference_state_dict() helper to load full checkpoints, bare
  EMA state_dicts, or inference files transparently.
- download_models.py prefetches combra's CLIP/DINOv2 backbones when installed;
  new pure-shell download_models.sh for offline nodes.
- Self-contained 2xH200 sbatch train scripts (256/512/1024) on the rocky
  partition, passing --save-inference-only/--combra-metrics.
- Hydra entry point train_hydra.py + configs/config.yaml deriving defaults
  from the click CLI (train.py main() refactored into launch_from_opts()).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FmSyhA8pWDzFQxhfYqzaip