### PR TITLE
Port san-v2 training/infra improvements into DiffiT-v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,63 @@
+# Changelog
+
+All notable changes to this fork (`DiffiT-v2`) are documented here.
+Format loosely follows [Keep a Changelog](https://keepachangelog.com/).
+
+## [Unreleased] — 2026-06-25
+
+### Added
+- **`--combra-metrics` training flag** (default `true`) — computes the combra
+  generative-quality metrics (`cmmd`, `fd_dinov2`, …) each snapshot tick,
+  **independent of `--num-fid-samples`** (the Inception FID/IS path). combra runs
+  only when the flag is on **and** the package is installed; logged to TensorBoard
+  under `Metrics/combra_*`. (`scripts/train.py`)
+- **Startup warning** when `--combra-metrics=true` but the `combra` package is not
+  installed (instead of silently skipping), with a hint to pass
+  `--combra-metrics=false` to silence it.
+- **`--save-inference-only` training flag** (default `false`) — additionally writes
+  a tiny `network-snapshot-<kimg>-inference.pt` (and `network-final-inference.pt`)
+  containing only the EMA weights, the smallest artifact for `gen_images.py` /
+  `sample.py`. (`scripts/train.py`)
+- **`extract_inference_state_dict()` helper** (`diffit/dist_util.py`) — normalises
+  anything the loaders read (a full checkpoint dict, an older bare EMA
+  `state_dict`, or a `*-inference.pt` file) down to the EMA weights, so
+  `gen_images.py` and `sample.py` load every snapshot format transparently.
+- **combra backbones in the pre-download step** — `scripts/download_models.py`
+  pre-fetches combra's CLIP / DINOv2 / FID backbones when combra is installed
+  (skips cleanly otherwise).
+- **`download_models.sh`** — pure `wget`/`curl`/`git` prefetch of the torch-hub /
+  CLIP weights (and the VAEs via `huggingface-cli` when present) into the standard
+  caches, for offline compute nodes with no Python environment.
+- **2× H200 sbatch train scripts** for 256×256 / 512×512 / 1024×1024
+  (`sbatch/h200/h200_train_2_gpu_*.sbatch`) — self-contained (resolve the repo
+  root, so submittable from `sbatch/`), queue on the **`rocky` partition**, and
+  pass `--save-inference-only True` / `--combra-metrics True`.
+- **Hydra entry point** — `train_hydra.py` + `configs/config.yaml`. Defaults are
+  derived by introspecting the `train.py` click CLI (single source of truth), so
+  `configs/config.yaml` only declares the required fields and new flags propagate
+  automatically. Both entry points call the same `train.launch_from_opts`.
+
+### Changed
+- **Snapshots are now full resumable checkpoints by default.**
+  `network-snapshot-<kimg>.pt` / `network-final.pt` now hold
+  `{model, ema, opt, scaler?, cur_nimg}` to match the `--resume` loader — **this
+  fixes resume**, which previously failed because snapshots saved only the EMA
+  `state_dict` while `--resume` expected the full dict. (Trade-off: snapshots are
+  ~4–5× larger; use `--save-inference-only` for the small inference artifact.)
+- **combra evaluation gating** — the whole-dataset eval reference is now selected
+  by `use_combra = --combra-metrics and combra-installed`, rather than purely by
+  whether combra happens to be importable.
+- **`train.py` refactor** — the body of the click `main()` moved into a reusable
+  `launch_from_opts(opts)` so the click and Hydra entry points share one code path.
+- **Install** — added `hydra-core>=1.3` to `requirements.txt` and
+  `pyproject.toml`.
+- **Docs** — README documents the two new flags, the full-checkpoint snapshot
+  format, the Hydra entry point, and the `download_models.sh` offline path.
+
+### Notes
+- DiffiT-v2 is a latent-diffusion model, so several san-v2 changelog items do not
+  apply and were intentionally **not** ported: `legacy.load_network_pkl` G_ema
+  mirroring (no G/D/G_ema split), the `timm==0.4.12` pin (DiffiT requires
+  `timm==0.9.16`), the `imgui`/`glfw`/`pyopengl`/`imageio-ffmpeg`/`ninja`
+  removals (never present), the `test.py`→`tests/test_cuda_ops.py` move (no custom
+  CUDA ops), and the FFHQ-leftover removals (ImageNet-based).


### PR DESCRIPTION
Ports the applicable items from the `san-v2` changelog into DiffiT-v2 (a latent-diffusion model). Architecture-specific san-v2 items are intentionally omitted (see Notes).

## What's included

- **`--combra-metrics` flag** (default `true`) — computes combra generative-quality metrics each snapshot tick, decoupled from the Inception FID/IS path, with a **startup warning** when combra is requested but not installed.
- **`--save-inference-only` flag + resume fix** — snapshots / `network-final.pt` now save a **full resumable checkpoint** (`model`/`ema`/`opt`/`scaler`/`cur_nimg`) by default, matching the `--resume` loader. This **fixes resume**, which previously failed because snapshots only saved the EMA `state_dict`. The flag additionally writes a tiny EMA-only `*-inference.pt`. A new `extract_inference_state_dict()` helper lets `gen_images.py` / `sample.py` load full checkpoints, old bare EMA state_dicts, or inference files transparently.
- **Downloader** — `download_models.py` prefetches combra's CLIP/DINOv2 backbones when installed; new pure-shell `download_models.sh` for offline nodes.
- **sbatch** — self-contained 2×H200 train scripts (256/512/1024) on the `rocky` partition, passing the new flags.
- **Hydra entry point** — `train_hydra.py` + `configs/config.yaml` deriving defaults from the click CLI (`main()` refactored into a shared `launch_from_opts()`).
- **Docs + CHANGELOG** — README updates for all of the above and a new `CHANGELOG.md`.

## Notes / intentionally not ported

DiffiT-v2 is a diffusion model, so these san-v2 items don't apply: `legacy.load_network_pkl` G_ema mirroring (no G/D/G_ema split), the `timm==0.4.12` pin (DiffiT requires `timm==0.9.16`), the imgui/glfw/pyopengl/imageio-ffmpeg/ninja removals (never present), the `test.py`→`tests/test_cuda_ops.py` move (no custom CUDA ops), and the FFHQ-leftover removals (ImageNet-based).

## Verification status

Syntax-checked all changed Python (`py_compile`), shell (`bash -n`), and YAML — all pass. The runtime checks (CLI `--help`/`--dry-run`, `pytest`, Hydra dry-run, and the snapshot/resume round-trip) **could not be run here** because torch/click/hydra aren't installed in this environment — they should be run on a GPU/conda node before merge.

> ⚠️ Behavior change: the default snapshot is now ~4–5× larger because it includes optimizer state (required for resume to work). Use `--save-inference-only True` to also emit the small inference artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FmSyhA8pWDzFQxhfYqzaip

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmSyhA8pWDzFQxhfYqzaip)_